### PR TITLE
防止背包内物品意外跑到银行 | Prevent items in the bag from being accidentally stacking to the bank

### DIFF
--- a/Core/Stacking.lua
+++ b/Core/Stacking.lua
@@ -26,8 +26,15 @@ function Stacking:Constructor()
 end
 
 function Stacking:Prepare()
-    self:InitBag(Pack:GetBag(BAG_TYPE.BAG))
-    self:InitBag(Pack:GetBag(BAG_TYPE.BANK))
+    -- When the bank is opened and the bag and the bank have the same items,
+    -- prevent the item in the bag from accidentally stacking to the bank.
+    local save = Pack.opts.save and Pack.opts.save()
+    if Pack.opts.bag or save then
+        self:InitBag(Pack:GetBag(BAG_TYPE.BAG))
+    end
+    if Pack.opts.bank or save then
+        self:InitBag(Pack:GetBag(BAG_TYPE.BANK))
+    end
 end
 
 function Stacking:InitBag(bag)


### PR DESCRIPTION
当银行打开，并且背包和银行里有相同物品时，防止背包内物品意外跑到银行。
意外是指：
1. “默认整理同时保存到银行”未启用。
2. 仅进行“整理背包”，不是“默认整理”。
3. 玩家可能完全没注意到背包内物品去了银行。
4. 最典型的情况是，玩家刚刚把部分物品从银行提取到背包，然后点了整理背包，物品又回到银行。
5. 玩家在打团时找不到自己放在背包内的物品：“我明明带了xxx，怎么不见了。”

When the bank is opened and the bag and the bank have the same items, prevent the item in the bag from accidentally stacking to the bank.

An accident is:
1. "Save to bank when default packing" is not enabled.
2. Only "Sort Bag", not "Default Packing".
3. The player may not even notice that these items in the bag went to the bank.
4. The most typical scenario is that the player just picked some items from the bank to the bag, then he sorting the bag, and these items returned to the bank.
5. The player can't find what he put in his bag when he in RAID: "I obviously brought xxx, but it was gone."
